### PR TITLE
Implement Contact Detail Screen UI

### DIFF
--- a/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
@@ -1,16 +1,67 @@
 package com.example.otpmanager.ui
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun ContactDetailScreen(modifier: Modifier = Modifier) {
-    Text(
-        "Contact Detail", modifier = modifier
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
             .fillMaxSize()
             .wrapContentSize()
-    )
+            .padding(16.dp)
+    ) {
+        var firstName by rememberSaveable { mutableStateOf("") }
+        OutlinedTextField(
+            value = firstName,
+            onValueChange = { firstName = it },
+            label = { Text("First name") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        var lastName by rememberSaveable { mutableStateOf("") }
+        OutlinedTextField(
+            value = lastName,
+            onValueChange = { lastName = it },
+            label = { Text("Last name") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        var phone by rememberSaveable { mutableStateOf("") }
+        OutlinedTextField(
+            value = phone,
+            onValueChange = { phone = it },
+            label = { Text("Phone") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        )
+    }
 }

--- a/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
@@ -33,7 +33,10 @@ import com.example.otpmanager.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ContactDetailScreen(modifier: Modifier = Modifier) {
+fun ContactDetailScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(topBar = {
         TopAppBar(
             title = {
@@ -43,7 +46,7 @@ fun ContactDetailScreen(modifier: Modifier = Modifier) {
                 )
             },
             navigationIcon = {
-                IconButton({}) {
+                IconButton(onBackClick) {
                     Icon(imageVector = Icons.Default.Clear, "")
                 }
             },
@@ -103,5 +106,5 @@ fun ContactDetailScreen(modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun ContactDetailScreenPreview() {
-    ContactDetailScreen()
+    ContactDetailScreen({})
 }

--- a/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Button
@@ -27,6 +28,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.otpmanager.R
@@ -92,8 +95,16 @@ fun ContactDetailScreen(
 
             var phone by rememberSaveable { mutableStateOf("") }
             OutlinedTextField(
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
                 value = phone,
-                onValueChange = { phone = it },
+                onValueChange = { input ->
+                    if (input.all { it.isDigit() }) {
+                        phone = input
+                    }
+                },
                 label = { Text(stringResource(R.string.phone)) },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/ContactDetailScreen.kt
@@ -7,10 +7,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,50 +26,82 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.otpmanager.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContactDetailScreen(modifier: Modifier = Modifier) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .fillMaxSize()
-            .wrapContentSize()
-            .padding(16.dp)
-    ) {
-        var firstName by rememberSaveable { mutableStateOf("") }
-        OutlinedTextField(
-            value = firstName,
-            onValueChange = { firstName = it },
-            label = { Text("First name") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
+    Scaffold(topBar = {
+        TopAppBar(
+            title = {
+                Text(
+                    stringResource(R.string.create_contact),
+                    style = MaterialTheme.typography.headlineMedium
+                )
+            },
+            navigationIcon = {
+                IconButton({}) {
+                    Icon(imageVector = Icons.Default.Clear, "")
+                }
+            },
+            actions = {
+                Button({}, modifier = Modifier.padding(16.dp)) {
+                    Text(stringResource(R.string.save))
+                }
+            }
         )
+    }) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .fillMaxSize()
+                .wrapContentSize()
+                .padding(it)
+                .padding(16.dp)
+        ) {
+            var firstName by rememberSaveable { mutableStateOf("") }
+            OutlinedTextField(
+                value = firstName,
+                onValueChange = { firstName = it },
+                label = { Text(stringResource(R.string.first_name)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        var lastName by rememberSaveable { mutableStateOf("") }
-        OutlinedTextField(
-            value = lastName,
-            onValueChange = { lastName = it },
-            label = { Text("Last name") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-        )
+            var lastName by rememberSaveable { mutableStateOf("") }
+            OutlinedTextField(
+                value = lastName,
+                onValueChange = { lastName = it },
+                label = { Text(stringResource(R.string.last_name)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        var phone by rememberSaveable { mutableStateOf("") }
-        OutlinedTextField(
-            value = phone,
-            onValueChange = { phone = it },
-            label = { Text("Phone") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-        )
+            var phone by rememberSaveable { mutableStateOf("") }
+            OutlinedTextField(
+                value = phone,
+                onValueChange = { phone = it },
+                label = { Text(stringResource(R.string.phone)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            )
+        }
     }
+}
+
+@Preview
+@Composable
+fun ContactDetailScreenPreview() {
+    ContactDetailScreen()
 }

--- a/app/src/main/java/com/example/otpmanager/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/navigation/NavGraph.kt
@@ -23,7 +23,7 @@ fun NavGraph(
             ContactScreen(onDetailClick = { navController.navigate(Screen.ContactDetail.route) })
         }
         composable(Screen.ContactDetail.route) {
-            ContactDetailScreen()
+            ContactDetailScreen({ navController.popBackStack() })
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">OTP Manager</string>
+    <string name="create_contact">Create contact</string>
+    <string name="save">Save</string>
+    <string name="first_name">First name</string>
+    <string name="last_name">Last name</string>
+    <string name="phone">Phone</string>
 </resources>


### PR DESCRIPTION
This PR adds the complete UI for the ContactDetailScreen.

Includes:
1. Input fields for first name, last name, and phone number.
2. Top App Bar with a Cancel icon that navigates back to the ContactScreen.
3. Save button in the top app bar (not functional yet).

Notes:
- The Save functionality will be implemented after setting up the Room database and ViewModel.
- Manual test done by launching the app and navigating to the Contact Detail screen. See attached video.

Next steps:
- Add ViewModel and Room database to enable saving contact data.
- Wire up Save button with validation and data persistence.

https://github.com/user-attachments/assets/60f0f614-b565-491b-8e6b-3fe20c37aef0