### PR TITLE
Add ViewModel, Repository, and Manual DI Setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".OTPManagerApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/otpmanager/OTPManagerApplication.kt
+++ b/app/src/main/java/com/example/otpmanager/OTPManagerApplication.kt
@@ -1,0 +1,16 @@
+package com.example.otpmanager
+
+import android.app.Application
+import com.example.otpmanager.data.ContactDao
+import com.example.otpmanager.data.ContactDatabase
+import com.example.otpmanager.data.ContactRepository
+import com.example.otpmanager.data.ContactRepositoryImpl
+
+class OTPManagerApplication : Application() {
+    private val contactDao: ContactDao by lazy {
+        ContactDatabase.getDatabase(this).contactDao()
+    }
+    val contactRepository: ContactRepository by lazy {
+        ContactRepositoryImpl(contactDao)
+    }
+}

--- a/app/src/main/java/com/example/otpmanager/data/ContactRepository.kt
+++ b/app/src/main/java/com/example/otpmanager/data/ContactRepository.kt
@@ -1,0 +1,10 @@
+package com.example.otpmanager.data
+
+import kotlinx.coroutines.flow.Flow
+
+interface ContactRepository {
+    fun getAllContacts(): Flow<List<Contact>>
+    suspend fun insertContact(contact: Contact)
+    suspend fun deleteContact(contact: Contact)
+    suspend fun updateContact(contact: Contact)
+}

--- a/app/src/main/java/com/example/otpmanager/data/ContactRepositoryImpl.kt
+++ b/app/src/main/java/com/example/otpmanager/data/ContactRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.example.otpmanager.data
+
+import kotlinx.coroutines.flow.Flow
+
+class ContactRepositoryImpl(private val contactDao: ContactDao) : ContactRepository {
+    override fun getAllContacts(): Flow<List<Contact>> = contactDao.getAll()
+
+    override suspend fun insertContact(contact: Contact) {
+        contactDao.insert(contact)
+    }
+
+    override suspend fun deleteContact(contact: Contact) {
+        contactDao.delete(contact)
+    }
+
+    override suspend fun updateContact(contact: Contact) {
+        contactDao.update(contact)
+    }
+}

--- a/app/src/main/java/com/example/otpmanager/data/ContactUiState.kt
+++ b/app/src/main/java/com/example/otpmanager/data/ContactUiState.kt
@@ -1,0 +1,5 @@
+package com.example.otpmanager.data
+
+data class ContactUiState(
+    val contacts: List<Contact> = emptyList()
+)

--- a/app/src/main/java/com/example/otpmanager/ui/ContactViewModel.kt
+++ b/app/src/main/java/com/example/otpmanager/ui/ContactViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.otpmanager.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.otpmanager.data.ContactRepository
+import com.example.otpmanager.data.ContactUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ContactViewModel(private val contactRepository: ContactRepository) : ViewModel() {
+    private val _uiState = MutableStateFlow(ContactUiState())
+    val uiState: StateFlow<ContactUiState>
+        get() = _uiState
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            contactRepository.getAllContacts().collect { contacts ->
+                _uiState.update { currentState ->
+                    currentState.copy(contacts = contacts)
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ roomRuntime = "2.7.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }


### PR DESCRIPTION
This PR introduces the `ContactViewModel`, `ContactRepository`, and application-level setup for manual dependency injection.

Changes
1. Added `ContactViewModel` with `StateFlow` to manage UI state
2. Created `ContactRepository` interface and its implementation
3. Initialized Room DB, DAO, and Repository in the `ContactApplication` class

Notes
1. `ViewModelFactory` will be added in the next PR as part of UI integration
2. Tests for `ViewModel` and `Repository` will also be added in the next PR
3. No UI or functional change yet — logic layer setup only